### PR TITLE
Use last-char to get the last character

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,6 @@
+// Dependencies
+var LastChar = require("last-char");
+
 /**
  * DoubleLast
  * Doubles the last letter.
@@ -10,7 +13,7 @@
  * @return {String} The modified string.
  */
 function DoubleLast(input, letters) {
-    var last = input.slice(-1);
+    var last = LastChar(input);
     if (!letters || ~letters.indexOf(last)) {
         return input + last;
     }

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "bugs": {
     "url": "https://github.com/IonicaBizau/double-last/issues"
   },
-  "homepage": "https://github.com/IonicaBizau/double-last#readme"
+  "homepage": "https://github.com/IonicaBizau/double-last#readme",
+  "dependencies": {
+    "last-char": "^1.0.0"
+  }
 }


### PR DESCRIPTION
`charAt` is faster than `slice`, so using [`last-char`](https://github.com/IonicaBizau/last-char). :sparkle: 
